### PR TITLE
Add default return for siradakiMusaitIndex

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -131,6 +131,7 @@ export default function SiraTakip() {
         return idx;
       }
     }
+    return -1; // Hiç müsait yoksa -1 döndür
   };
 
   const siradakiKisi = () => {


### PR DESCRIPTION
## Summary
- ensure `siradakiMusaitIndex` always returns a number

## Testing
- `npm install`
- `CI=true npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68444e173f8483338f9406dfa5435f37