### PR TITLE
Add plus button for queue count

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -314,16 +314,24 @@ export default function SiraTakip() {
           {/* Sol tarafta çağrı butonları */}
           <div className="flex gap-[0.3vw] items-center">
             <button
-              onClick={() => {
-                const yeniSayi = callCount + 1;
-                setCallCount(yeniSayi);
-                guncelleFirebase({ callCount: yeniSayi });
-              }}
               className={`px-[1vw] py-[0.6vh] rounded-md font-semibold text-white shadow-md transition text-[clamp(1rem,0.8vw,1.8rem)] w-auto ${
                 blink ? "bg-red-600 animate-pulse" : "bg-red-500 hover:bg-red-600"
               }`}
             >
               Çağrı ({callCount})
+            </button>
+
+            <button
+              onClick={() => {
+                const yeniSayi = callCount + 1;
+                setCallCount(yeniSayi);
+                guncelleFirebase({ callCount: yeniSayi });
+              }}
+              className={`px-[0.4vw] py-[0.6vh] rounded-md font-semibold text-white shadow-md transition text-[clamp(1rem,0.8vw,1.8rem)] w-auto ${
+                blink ? "bg-gray-600 animate-pulse" : "bg-gray-600 hover:bg-gray-700"
+              }`}
+            >
+              +
             </button>
 
             <button


### PR DESCRIPTION
## Summary
- stop incrementing call count on the main call button
- add a new plus button next to the minus button for adjusting the queue

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d04c26a8833385c2e497686e83bb