### PR TITLE
Enhance call controls with animation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -46,3 +46,19 @@
     transform: rotate(360deg);
   }
 }
+
+@keyframes ring {
+  0%, 100% {
+    transform: rotate(0);
+  }
+  10%, 30%, 50%, 70% {
+    transform: rotate(-15deg);
+  }
+  20%, 40%, 60%, 80% {
+    transform: rotate(15deg);
+  }
+}
+
+.ring {
+  animation: ring 0.6s ease-in-out;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -322,15 +322,17 @@ export default function SiraTakip() {
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
                 fill="currentColor"
-                className="w-[1.2vw] h-[1.2vw] min-w-[20px] min-h-[20px]"
+                className={`w-[1.2vw] h-[1.2vw] min-w-[20px] min-h-[20px] ${
+                  callCount > 0 ? "animate-bounce ring" : ""
+                }`}
               >
                 <path
                   fillRule="evenodd"
-                  d="M1.5 4.5a3 3 0 013-3h1.372c.86 0 1.61.586 1.819 1.42l1.105 4.423a1.875 1.875 0 01-.694 1.955l-1.293.97c-.135.101-.164.249-.126.352a11.285 11.285 0 006.697 6.697c.103.038.25.009.352-.126l.97-1.293a1.875 1.875 0 011.955-.694l4.423 1.105c.834.209 1.42.959 1.42 1.82V19.5a3 3 0 01-3 3h-2.25C8.552 22.5 1.5 15.448 1.5 6.75V4.5z"
+                  d="M5.25 9a6.75 6.75 0 0113.5 0v.75c0 2.123.807 4.057 2.118 5.52a.75.75 0 01-.297 1.206 24.564 24.564 0 01-4.831 1.243 3.75 3.75 0 11-7.48 0 24.585 24.585 0 01-4.831-1.244.75.75 0 01-.298-1.205A8.217 8.217 0 005.25 9.75V9zm4.502 8.9a2.25 2.25 0 104.496 0 25.057 25.057 0 01-4.496 0z"
                   clipRule="evenodd"
                 />
               </svg>
-              <span>({callCount})</span>
+              <span>Çağrı Sayısı: {callCount}</span>
             </button>
 
             <button
@@ -339,7 +341,7 @@ export default function SiraTakip() {
                 setCallCount(yeniSayi);
                 guncelleFirebase({ callCount: yeniSayi });
               }}
-              className={`p-[0.5vw] rounded-md font-semibold text-white shadow-md transition text-[clamp(1rem,0.8vw,1.8rem)] w-auto ${
+              className={`p-[0.3vw] rounded-md font-semibold text-white shadow-md transition text-[clamp(1rem,0.8vw,1.8rem)] w-auto ${
                 blink ? "bg-gray-600 animate-pulse" : "bg-gray-600 hover:bg-gray-700"
               }`}
               aria-label="Çağrı Artır"
@@ -348,7 +350,7 @@ export default function SiraTakip() {
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
                 fill="currentColor"
-                className="w-[1.2vw] h-[1.2vw] min-w-[20px] min-h-[20px]"
+                className="w-[1vw] h-[1vw] min-w-[20px] min-h-[20px]"
               >
                 <path
                   fillRule="evenodd"
@@ -368,12 +370,12 @@ export default function SiraTakip() {
                 });
               }}
               disabled={callCount === 0}
-              className={`p-[0.5vw] rounded-md font-semibold text-white shadow-md transition text-[clamp(1rem,0.8vw,1.8rem)] w-auto ${
+              className={`p-[0.3vw] rounded-md font-semibold text-white shadow-md transition text-[clamp(1rem,0.8vw,1.8rem)] w-auto ${
                 callCount === 0
                   ? "bg-gray-400 opacity-50 cursor-not-allowed"
                   : blink
-                  ? "bg-gray-600 animate-pulse"
-                  : "bg-gray-600 hover:bg-gray-700"
+                    ? "bg-gray-600 animate-pulse"
+                    : "bg-gray-600 hover:bg-gray-700"
               }`}
               aria-label="Çağrı Azalt"
             >
@@ -381,7 +383,7 @@ export default function SiraTakip() {
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
                 fill="currentColor"
-                className="w-[1.2vw] h-[1.2vw] min-w-[20px] min-h-[20px]"
+                className="w-[1vw] h-[1vw] min-w-[20px] min-h-[20px]"
               >
                 <path
                   fillRule="evenodd"


### PR DESCRIPTION
## Summary
- show a bell icon and text for call count
- make plus/minus buttons smaller
- add bounce/ring animation when there are pending calls

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844e7ca6af08333824b135e101b57d9