### PR TITLE
Fix alignment for status label

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -471,7 +471,7 @@ export default function SiraTakip() {
                       </button>
                     </div>
                   ) : (
-                    <p className="italic text-[clamp(0.6rem,0.6vw,0.8rem)]">Durum: {emp.status}</p>
+                    <p className="italic text-[clamp(0.6rem,0.6vw,0.8rem)] w-[10ch] whitespace-nowrap">Durum: {emp.status}</p>
                   )}
                 </div>
 


### PR DESCRIPTION
## Summary
- keep status labels left-aligned by reserving width for the text

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684625c635388333ae1805fc244e2533