### PR TITLE
Add footer legend for status colors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -507,6 +507,9 @@ export default function SiraTakip() {
         </div>
       </div>
       <footer className="w-full text-center py-2 mt-auto text-[10px] sm:text-xs text-gray-400 border-t border-gray-200 dark:border-slate-700 bg-inherit">
+        <div className="w-full text-left mb-1">
+          🟢 Müsait 🔴 Çalışıyor 🟡 Molada ⚪ İzinli
+        </div>
         <span>Created by Ali Bekir Özer</span>
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- show status legend above footer text

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684632c132e48333bd4a8e9766a6a59f