### PR TITLE
Add arrow toggle for legend

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -511,8 +511,9 @@ export default function SiraTakip() {
           <button
             onClick={() => setShowLegend(!showLegend)}
             className="mr-[0.5vw] text-blue-600 hover:text-blue-800 underline"
+            aria-label={showLegend ? "Gizle" : "Göster"}
           >
-            {showLegend ? "Gizle" : "Göster"}
+            {showLegend ? "<" : ">"}
           </button>
           {showLegend && (
             <>


### PR DESCRIPTION
## Summary
- show `<` or `>` on the legend toggle button

## Testing
- `npm test --silent -- -w=0` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68497a691158833399544fa227442d13