### PR TITLE
Implement per-user logs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -499,9 +499,14 @@ export default function SiraTakip() {
               <h2 className="text-[clamp(1rem,1vw,1.5rem)] font-semibold mb-[0.8vh]">📋 Bugünkü Çağrı Kayıtları</h2>
               <div className="flex-1 min-h-0 overflow-y-auto">
                 <ul className="list-disc pl-[1vw] sm:pl-[1.5vw] text-[clamp(0.65rem,0.7vw,1rem)] space-y-[0.4vh]">
-                  {(logByDate[todayKey] || []).map((entry, index) => (
-                    <li key={index}>{entry.time} - {entry.person} {entry.action ? entry.action : "çağrıyı aldı"}</li>
-                  ))}
+                  {(logByDate[todayKey] || [])
+                    .filter((entry) => entry.person === userName)
+                    .map((entry, index) => (
+                      <li key={index}>
+                        {entry.time} - {entry.person}{" "}
+                        {entry.action ? entry.action : "çağrıyı aldı"}
+                      </li>
+                    ))}
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- filter today's logs by signed-in user only

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3a7599648333873367eaf122634f