### PR TITLE
Fix user alias handling and log filtering

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,10 @@ export default function SiraTakip() {
   const [logByDate, setLogByDate] = useState({});
   const [showLegend, setShowLegend] = useState(true);
   const todayKey = new Date().toISOString().split("T")[0];
-  const userName = auth.currentUser?.displayName || "Kullanıcı";
+
+  const currentUserId = auth.currentUser?.uid;
+  const userEntry = activeList.find((emp) => emp.uid === currentUserId);
+  const userName = userEntry?.name || auth.currentUser?.displayName || "Kullanıcı";
 
   // Durum rengi fonksiyonu: durum adları ve renkler güncellendi
   const durumRengi = (status) => {
@@ -68,9 +71,12 @@ export default function SiraTakip() {
   }, []);
 
   useEffect(() => {
-  const ad = auth.currentUser?.displayName || "";
-  setBenimAdim(ad);
-}, []);
+    const ad =
+      activeList.find((emp) => emp.uid === auth.currentUser?.uid)?.name ||
+      auth.currentUser?.displayName ||
+      "";
+    setBenimAdim(ad);
+  }, [activeList]);
 
   useEffect(() => {
     const dataRef = ref(realtimeDB, "siraTakip");


### PR DESCRIPTION
## Summary
- derive `userName` from the active list so the welcome message matches the list
- update `benimAdim` based on the active list entry
- ensure the daily log filters by the resolved `userName`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_685d42f364b08333a02c3ba8fcc07b7d