### PR TITLE
Show status read-only unless editing

### DIFF
--- a/src/AdminPanel.js
+++ b/src/AdminPanel.js
@@ -314,19 +314,7 @@ export default function AdminPanel() {
                     <option value="Müsait">Müsait</option>
                   </select>
                 ) : (
-                  <select
-                    value={
-                      activeList.find((emp) => emp.uid === user.uid)?.status || ""
-                    }
-                    onChange={(e) => updateStatus(user, e.target.value)}
-                    className="border p-1"
-                  >
-                    <option value="">Seç...</option>
-                    <option value="Molada">Molada</option>
-                    <option value="İzinli">İzinli</option>
-                    <option value="Çalışıyor">Çalışıyor</option>
-                    <option value="Müsait">Müsait</option>
-                  </select>
+                  activeList.find((emp) => emp.uid === user.uid)?.status || ""
                 )}
               </td>
               <td className="p-2 border text-center">


### PR DESCRIPTION
## Summary
- only allow status updates while in edit mode

## Testing
- `npm test --silent --yes` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685de39214c083339a9cc886adbb51ab