### PR TITLE
Ensure consistent 24h time formatting

### DIFF
--- a/Backup/src/App.js
+++ b/Backup/src/App.js
@@ -6,6 +6,7 @@ import { signOut } from "firebase/auth";
 import { auth } from "./firebase";
 import AdminPanel from "./AdminPanel";
 import { update } from "firebase/database";
+import { formatTime } from "./timeUtils";
 
 export default function SiraTakip() {
   const [allEmployees, setAllEmployees] = useState([]);
@@ -185,7 +186,7 @@ export default function SiraTakip() {
         activeList.findIndex(emp => emp.status === "Müsait");
 
       const person = activeList[currentUserIndex].name;
-      const timestamp = new Date().toLocaleTimeString();
+      const timestamp = formatTime();
       const yeniLog = [
         { 
           person, 
@@ -218,7 +219,7 @@ export default function SiraTakip() {
     let yeniIndex = currentIndex; // olduğu gibi kalsın, değiştirme
 
     const person = updated[index].name;
-    const timestamp = new Date().toLocaleTimeString();
+    const timestamp = formatTime();
     const yeniLog = [{ person, time: timestamp, action: `Durum: ${eskiStatus} → ${status}` }, ...(logByDate[todayKey] || [])].slice(0, 200);
     const updatedLogByDate = { ...logByDate, [todayKey]: yeniLog };
 
@@ -268,7 +269,7 @@ export default function SiraTakip() {
         <div className="flex items-center gap-[0.25vw] text-[clamp(0.7rem,0.5vw,1.2rem)] text-gray-600 dark:text-gray-400 mt-[0.25vh]">
           <span>🕒</span>
           <span>
-            {time.toLocaleTimeString("tr-TR", { hour: "2-digit", minute: "2-digit", second: "2-digit" })} -
+            {formatTime(time)} -
             {time.toLocaleDateString("tr-TR")}
           </span>
         </div>

--- a/src/AdminPanel.js
+++ b/src/AdminPanel.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { collection, getDocs, doc, updateDoc, deleteDoc, setDoc } from "firebase/firestore";
 import { firestoreDB, auth, realtimeDB, functions } from "./firebase";
+import { formatTime } from "./timeUtils";
 import { ref, get, set } from "firebase/database";
 import {
   getAuth,
@@ -88,7 +89,7 @@ export default function AdminPanel() {
     const logData = logSnap.val() || {};
     const entry = {
       person: user.name,
-      time: new Date().toLocaleTimeString(),
+      time: formatTime(),
       action: `Durum: ${oldStatus || "-"} → ${status}`,
     };
     const updatedForToday = [

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { realtimeDB } from "./firebase";
 import { signOut } from "firebase/auth";
 import { auth } from "./firebase";
 import AdminPanel from "./AdminPanel";
+import { formatTime } from "./timeUtils";
 import { update } from "firebase/database";
 
 
@@ -197,7 +198,7 @@ export default function SiraTakip() {
         activeList.findIndex(emp => emp.status === "Müsait");
 
       const person = activeList[currentUserIndex].name;
-      const timestamp = new Date().toLocaleTimeString();
+      const timestamp = formatTime();
       const yeniLog = [
         { 
           person, 
@@ -232,7 +233,7 @@ export default function SiraTakip() {
     let yeniIndex = currentIndex; // olduğu gibi kalsın, değiştirme
 
     const person = updated[index].name;
-    const timestamp = new Date().toLocaleTimeString();
+    const timestamp = formatTime();
     const yeniLog = [{ person, time: timestamp, action: `Durum: ${eskiStatus} → ${status}` }, ...(logByDate[todayKey] || [])].slice(0, 200);
     const updatedLogByDate = { ...logByDate, [todayKey]: yeniLog };
 
@@ -291,7 +292,7 @@ export default function SiraTakip() {
             <div className="flex items-center gap-[0.25vw] text-[clamp(0.7rem,0.5vw,1.2rem)] text-gray-600 dark:text-gray-400 mt-[0.25vh]">
               <span>🕒</span>
               <span>
-                {time.toLocaleTimeString("tr-TR", { hour: "2-digit", minute: "2-digit", second: "2-digit" })} -
+                {formatTime(time)} -
                 {time.toLocaleDateString("tr-TR")}
               </span>
             </div>

--- a/src/timeUtils.js
+++ b/src/timeUtils.js
@@ -1,0 +1,8 @@
+export function formatTime(date = new Date()) {
+  return date.toLocaleTimeString('tr-TR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}


### PR DESCRIPTION
## Summary
- add `formatTime` helper
- use `formatTime` across app and admin panel
- update backup project

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f47755788333af2094c7e6a9ff5d