### PR TITLE
Fix log time format

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import { realtimeDB } from "./firebase";
 import { signOut } from "firebase/auth";
 import { auth } from "./firebase";
 import AdminPanel from "./AdminPanel";
-import { formatTime } from "./timeUtils";
+import { formatTime, ensure24Hour } from "./timeUtils";
 import { update } from "firebase/database";
 
 
@@ -510,7 +510,7 @@ export default function SiraTakip() {
                     .filter((entry) => entry.person === userName)
                     .map((entry, index) => (
                       <li key={index}>
-                        {entry.time} - {entry.person}{" "}
+                        {ensure24Hour(entry.time)} - {entry.person}{" "}
                         {entry.action ? entry.action : "çağrıyı aldı"}
                       </li>
                     ))}

--- a/src/timeUtils.js
+++ b/src/timeUtils.js
@@ -6,3 +6,10 @@ export function formatTime(date = new Date()) {
     hour12: false,
   });
 }
+
+export function ensure24Hour(timeStr) {
+  if (!timeStr) return '';
+  const parsed = new Date(`1970-01-01 ${timeStr}`);
+  if (isNaN(parsed)) return timeStr;
+  return formatTime(parsed);
+}


### PR DESCRIPTION
## Summary
- add `ensure24Hour` helper for time strings
- use the new helper so daily call logs show 24h time

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863fb37c28c8333806de6cb8162d2ab