### PR TITLE
Add daily heatmap and Excel export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.0",
         "react-scripts": "5.0.1",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "xlsx": "^0.18.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4810,6 +4811,15 @@
         "node": ">=8.9"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -5804,6 +5814,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6026,6 +6049,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -6252,6 +6284,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -8526,6 +8570,15 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -14876,6 +14929,18 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -16904,6 +16969,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -17275,6 +17358,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "xlsx": "^0.18.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/Stats.js
+++ b/src/Stats.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { ref, get } from "firebase/database";
 import { realtimeDB } from "./firebase";
 import { Bar } from "react-chartjs-2";
+import * as XLSX from "xlsx";
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -86,7 +87,7 @@ function computeStats(logByDate, activeUsers, startDate, endDate) {
   return Object.values(stats);
 }
 
-function computeHeatmap(logByDate, startDate, endDate) {
+function computeHourlyHeatmap(logByDate, startDate, endDate) {
   const heatmap = [];
   const start = new Date(startDate);
   const end = new Date(endDate);
@@ -104,6 +105,21 @@ function computeHeatmap(logByDate, startDate, endDate) {
   return heatmap;
 }
 
+function computeDailyHeatmap(logByDate, startDate, endDate) {
+  const heatmap = [];
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    const dateStr = d.toISOString().split("T")[0];
+    let count = 0;
+    (logByDate[dateStr] || []).forEach((entry) => {
+      if (entry.action?.includes("çağrıyı aldı")) count += 1;
+    });
+    heatmap.push({ date: dateStr, count });
+  }
+  return heatmap;
+}
+
 export default function Stats() {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -115,7 +131,8 @@ export default function Stats() {
   const [selectedDay, setSelectedDay] = useState(
     new Date().toISOString().split("T")[0]
   );
-  const [heatmap, setHeatmap] = useState([]);
+  const [hourlyHeatmap, setHourlyHeatmap] = useState([]);
+  const [dailyHeatmap, setDailyHeatmap] = useState([]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -147,7 +164,8 @@ export default function Stats() {
       e = new Date(d);
     }
     setData(computeStats(logs, activeList, s, e));
-    setHeatmap(computeHeatmap(logs, s, e));
+    setHourlyHeatmap(computeHourlyHeatmap(logs, s, e));
+    setDailyHeatmap(computeDailyHeatmap(logs, s, e));
   }, [logs, activeList, filter, startDate, endDate, selectedDay, loading]);
 
   if (loading) return <div className="p-4">Yükleniyor...</div>;
@@ -170,10 +188,31 @@ export default function Stats() {
     ],
   };
 
-  const maxCount = Math.max(
-    0,
-    ...heatmap.flatMap((h) => h.counts)
-  );
+  const maxCount = Math.max(0, ...dailyHeatmap.map((h) => h.count));
+  const weeks = [];
+  for (let i = 0; i < dailyHeatmap.length; i += 7) {
+    weeks.push(dailyHeatmap.slice(i, i + 7));
+  }
+
+  const exportExcel = () => {
+    const wsData = [];
+    const header = ["Tarih"];
+    for (let h = 8; h <= 18; h++) {
+      header.push(h.toString().padStart(2, "0"));
+    }
+    wsData.push(header);
+    hourlyHeatmap.forEach((row) => {
+      const rowData = [row.date];
+      for (let h = 8; h <= 18; h++) {
+        rowData.push(row.counts[h] || 0);
+      }
+      wsData.push(rowData);
+    });
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.aoa_to_sheet(wsData);
+    XLSX.utils.book_append_sheet(wb, ws, "Heatmap");
+    XLSX.writeFile(wb, "heatmap.xlsx");
+  };
 
   return (
     <div className="min-h-screen bg-gray-100 p-6">
@@ -219,32 +258,28 @@ export default function Stats() {
           <Bar data={chartData} />
         </div>
         <div className="overflow-x-auto mb-8">
+          <button
+            onClick={exportExcel}
+            className="mb-2 px-2 py-1 border rounded"
+          >
+            Excel İndir
+          </button>
           <table className="text-xs border-collapse">
-            <thead>
-              <tr>
-                <th className="p-1 border">Tarih</th>
-                {Array.from({ length: 24 }).map((_, i) => (
-                  <th key={i} className="p-1 border">
-                    {i}
-                  </th>
-                ))}
-              </tr>
-            </thead>
             <tbody>
-              {heatmap.map((row) => (
-                <tr key={row.date}>
-                  <td className="p-1 border whitespace-nowrap">{row.date}</td>
-                  {row.counts.map((c, i) => (
+              {weeks.map((week, wi) => (
+                <tr key={wi}>
+                  {week.map((day) => (
                     <td
-                      key={i}
-                      className="border text-center"
+                      key={day.date}
+                      className="p-2 border text-center"
                       style={{
                         backgroundColor: `rgba(252,165,165,${
-                          maxCount ? c / maxCount : 0
+                          maxCount ? day.count / maxCount : 0
                         })`,
                       }}
                     >
-                      {c > 0 ? c : ""}
+                      <div className="text-[10px]">{day.date}</div>
+                      <div>{day.count > 0 ? day.count : ""}</div>
                     </td>
                   ))}
                 </tr>


### PR DESCRIPTION
## Summary
- add `xlsx` dependency for Excel export
- add daily heatmap computation and hourly heatmap for export
- show daily heatmap grid instead of hourly table
- allow exporting hourly data (08-18) to Excel

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68640e205f60833380f04efab3e65d04