### PR TITLE
Fix daily stats to stop at current time

### DIFF
--- a/src/Stats.js
+++ b/src/Stats.js
@@ -44,7 +44,11 @@ function computeStats(logByDate, activeUsers, startDate, endDate) {
     const day = new Date(date);
     if (isNaN(day) || day < start || day > end) continue;
     const workStart = new Date(`${date}T08:30:00`);
-    const workEnd = new Date(`${date}T17:30:00`);
+    let workEnd = new Date(`${date}T17:30:00`);
+    const today = new Date();
+    if (day.toDateString() === today.toDateString() && today < workEnd) {
+      workEnd = today;
+    }
     const sorted = [...logs].sort(
       (a, b) => new Date(`${date}T${a.time}`) - new Date(`${date}T${b.time}`)
     );


### PR DESCRIPTION
## Summary
- adjust daily statistics calculation so the time range ends at the current time on the current day

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68668aab476083338d5e1108388732d5