### PR TITLE
Make active user list scrollable and match call log height

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -274,7 +274,7 @@ export default function SiraTakip() {
   const musaitSayisi = activeList.filter(emp => emp.status === "Müsait").length;
 
   return (
-    <div className="bg-white text-black min-h-screen w-full max-w-[100vw] overflow-x-hidden flex flex-col box-border px-[0.5vw]" style={{ overflowY: 'hidden' }}>
+    <div className="bg-white text-black min-h-screen w-full max-w-[100vw] overflow-x-hidden flex flex-col box-border px-[0.5vw] py-[2vh]" style={{ overflowY: 'hidden' }}>
       {/* Üst Bar */}
       <header className="sticky top-0 z-20 bg-inherit backdrop-blur-md border-b border-gray-300/20 py-[0.75vh] mb-[1vh] w-full max-w-full">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-[0.5vw] w-full">
@@ -415,10 +415,11 @@ export default function SiraTakip() {
         </div>
       </div>
       <div className="flex-1 flex flex-col lg:flex-row w-full gap-[0.5vw] mt-[2vh] overflow-hidden">
-        <div className="w-full lg:w-[75%] pr-0 lg:pr-[0.5vw] space-y-[0.5vh] overflow-visible">
-          <h2 className="text-[clamp(1rem,1vw,1.3rem)] font-semibold mb-[0.8vh]">Aktif Kullanıcılar</h2>
-          <div className="space-y-[0.6vh]">
-            {displayIndices.map((i) => {
+        <div className="w-full lg:w-[75%] pr-0 lg:pr-[0.5vw] flex flex-col h-full">
+          <div className="bg-white border border-transparent rounded-[0.7vw] shadow-sm px-[1vw] pt-[1vh] pb-[1vh] h-full flex flex-col">
+            <h2 className="text-[clamp(1rem,1vw,1.3rem)] font-semibold mb-[0.8vh]">Aktif Kullanıcılar</h2>
+            <div className="flex-1 min-h-0 overflow-y-auto space-y-[0.6vh]">
+            {displayIndices.map((i, idx) => {
               const emp = activeList[i];
               const isCurrentUser = emp.uid === auth.currentUser?.uid;
               return (
@@ -428,6 +429,7 @@ export default function SiraTakip() {
                   "flex flex-col gap-[0.4vh] rounded-[0.4vw] shadow-sm p-[0.6vw] duration-200",
                   "bg-white",
                   i === siradakiMusaitIndex() && "bg-blue-50 border-2 border-green-500",
+                  idx === 0 && "sticky top-0 z-10 bg-white"
                 )}
               >
                 {/* Üst Satır: Durum rengi ve isim */}
@@ -508,8 +510,8 @@ export default function SiraTakip() {
             </div>
           </div>
         </div>
-        <div className="w-full lg:w-1/4 flex flex-col">
-          <div className="border-l-0 lg:pl-[1.5vw] pr-0" style={{height: 'calc(104vh - 20vw)'}}>
+        <div className="w-full lg:w-1/4 flex flex-col h-full">
+          <div className="border-l-0 lg:pl-[1.5vw] pr-0 h-full">
             <div className="bg-white border border-gray-300 rounded-[0.7vw] shadow-sm px-[1vw] pt-[1vh] pb-[1vh] mr-0 lg:mr-[1vw] h-full flex flex-col">
               <h2 className="text-[clamp(1rem,1vw,1.5rem)] font-semibold mb-[0.8vh]">📋 Bugünkü Çağrı Kayıtları</h2>
               <div className="flex-1 min-h-0 overflow-y-auto">


### PR DESCRIPTION
## Summary
- add vertical padding to main container
- wrap active user list in a borderless card
- make first user sticky
- ensure both lists use equal height

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f26f28808333ac507b0a7a602cea