### PR TITLE
Align summary stats with user rows

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -502,7 +502,7 @@ export default function SiraTakip() {
               </div>
             );
             })}
-            <div className="flex justify-end mt-[0.6vh] text-[clamp(0.8rem,0.7vw,1rem)] text-gray-600 font-medium">
+            <div className="flex justify-between items-center mt-[0.6vh] text-[clamp(0.8rem,0.7vw,1rem)] text-gray-600 font-medium p-[0.6vw]">
               <span className="mr-[1vw]">Toplam kullanıcı sayısı: {toplamKullanici}</span>
               <span>Müsait: {musaitSayisi}</span>
             </div>


### PR DESCRIPTION
## Summary
- align summary stats on main page with user row layout

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686e1cc328908333a6cad6002457bea0