### PR TITLE
Add env var for Teams webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,16 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+## Updating the Teams webhook
+
+Cloud Functions send notifications to Microsoft Teams. The webhook URL can be
+configured via the `TEAMS_WEBHOOK_URL` environment variable. If the variable is
+not set, the default URL defined in `functions/index.js` will be used.
+
+After changing the webhook or the function code, deploy the functions again:
+
+```bash
+firebase deploy --only functions
+```
+

--- a/functions/index.js
+++ b/functions/index.js
@@ -6,7 +6,9 @@ const fetch = require("node-fetch");
 admin.initializeApp();
 
 const { onValueUpdated } = require("firebase-functions/v2/database"); 
-const TEAMS_WEBHOOK_URL = "https://kocsistem.webhook.office.com/webhookb2/44660f66-4726-4a54-842b-1c313fd46f06@1e1aa76b-4b02-45f4-9417-2e13eb0da973/IncomingWebhook/feaff87babfa4ad79698fecd90506c45/cf410a20-3801-452e-8fea-eb078c94b436/V2HLOiBO5dUtI99j9l0VGzP03M3uYj5rDVrSbNsMtuEl01";
+const TEAMS_WEBHOOK_URL =
+  process.env.TEAMS_WEBHOOK_URL ||
+  "https://kocsistem.webhook.office.com/webhookb2/44660f66-4726-4a54-842b-1c313fd46f06@1e1aa76b-4b02-45f4-9417-2e13eb0da973/IncomingWebhook/feaff87babfa4ad79698fecd90506c45/cf410a20-3801-452e-8fea-eb078c94b436/V2HLOiBO5dUtI99j9l0VGzP03M3uYj5rDVrSbNsMtuEl01";
 exports.bildirimGonder = onValueWritten(
   {
     region: "europe-west1",


### PR DESCRIPTION
## Summary
- allow TEAMS webhook URL to be configured via `TEAMS_WEBHOOK_URL`
- document redeploy instructions and how to override the webhook URL

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878147b0954833386f9f7b163463bc0