### PR TITLE
Update Teams webhook constant

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -6,9 +6,14 @@ const fetch = require("node-fetch");
 admin.initializeApp();
 
 const { onValueUpdated } = require("firebase-functions/v2/database"); 
+const DEFAULT_TEAMS_WEBHOOK_URL =
+  "https://kocsistem.webhook.office.com/webhookb2/" +
+  "44660f66-4726-4a54-842b-1c313fd46f06@1e1aa76b-4b02-45f4-9417-2e13eb0da973/" +
+  "IncomingWebhook/ee9e8e581a9947978427c0251aa55949/" +
+  "cf410a20-3801-452e-8fea-eb078c94b436/V2s7VscePkYeDL_oi1CU0E1isjutKTu5F0uKoQJeD_L9Q1";
+
 const TEAMS_WEBHOOK_URL =
-  process.env.TEAMS_WEBHOOK_URL ||
-  "https://kocsistem.webhook.office.com/webhookb2/44660f66-4726-4a54-842b-1c313fd46f06@1e1aa76b-4b02-45f4-9417-2e13eb0da973/IncomingWebhook/ee9e8e581a9947978427c0251aa55949/cf410a20-3801-452e-8fea-eb078c94b436/V2s7VscePkYeDL_oi1CU0E1isjutKTu5F0uKoQJeD_L9Q1";
+  process.env.TEAMS_WEBHOOK_URL || DEFAULT_TEAMS_WEBHOOK_URL;
 exports.bildirimGonder = onValueWritten(
   {
     region: "europe-west1",


### PR DESCRIPTION
## Summary
- add `DEFAULT_TEAMS_WEBHOOK_URL` constant to store the Teams webhook
- reference the new constant when building the webhook URL

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687818e0ebe8833399a96f1322108844