### PR TITLE
Fix region mismatch for updateUserCredentials

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -18,5 +18,5 @@ const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const realtimeDB = getDatabase(app);
 export const firestoreDB = getFirestore(app);
-export const functions = getFunctions(app);
+export const functions = getFunctions(app, "europe-west1");
 


### PR DESCRIPTION
## Summary
- configure Firebase functions to use europe-west1 region so the `updateUserCredentials` callable works

## Testing
- `npm install`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_687942d33818833389a430de2d618b07