### PR TITLE
Enable role-based admin access

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,12 +4,11 @@ import { ref, set, onValue } from "firebase/database";
 import { realtimeDB } from "./firebase";
 import { signOut } from "firebase/auth";
 import { auth } from "./firebase";
-import AdminPanel from "./AdminPanel";
 import { formatTime, ensure24Hour } from "./timeUtils";
 import { update } from "firebase/database";
 
 
-export default function SiraTakip() {
+export default function SiraTakip({ isAdmin }) {
   const [allEmployees, setAllEmployees] = useState([]);
   const [selectedNames, setSelectedNames] = useState([]);
   const [activeList, setActiveList] = useState([]);
@@ -294,7 +293,7 @@ export default function SiraTakip() {
               <p className="text-gray-800 truncate">
                 Hoş geldin, <span className="font-semibold text-blue-600">{userName || "Kullanıcı"}</span>
               </p>
-              {auth.currentUser?.email === "muhammedalibekir@gmail.com" && (
+              {isAdmin && (
                 <a
                   href="/admin"
                   className="inline-block mt-[0.5vh] text-[clamp(0.7rem,0.5vw,1.2rem)] text-blue-500 hover:underline hover:text-blue-600 transition"

--- a/src/MainApp.js
+++ b/src/MainApp.js
@@ -2,7 +2,8 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { onAuthStateChanged } from "firebase/auth";
-import { auth } from "./firebase";
+import { doc, getDoc } from "firebase/firestore";
+import { auth, firestoreDB } from "./firebase";
 import App from "./App";
 import Login from "./Login";
 import AdminPanel from "./AdminPanel";
@@ -11,10 +12,22 @@ import Stats from "./Stats";
 export default function MainApp() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
       setUser(firebaseUser);
+      if (firebaseUser) {
+        try {
+          const snap = await getDoc(doc(firestoreDB, "users", firebaseUser.uid));
+          setIsAdmin(snap.exists() && snap.data().role === "admin");
+        } catch (err) {
+          console.error("Failed to fetch user role", err);
+          setIsAdmin(false);
+        }
+      } else {
+        setIsAdmin(false);
+      }
       setLoading(false);
     });
     return () => unsubscribe();
@@ -31,11 +44,11 @@ export default function MainApp() {
           </>
         ) : (
           <>
-            <Route path="/" element={<App />} />
+            <Route path="/" element={<App isAdmin={isAdmin} />} />
             <Route
               path="/admin"
               element={
-                user.email === "muhammedalibekir@gmail.com" ? (
+                isAdmin ? (
                   <AdminPanel />
                 ) : (
                   <Navigate to="/" />
@@ -45,7 +58,7 @@ export default function MainApp() {
             <Route
               path="/admin/stats"
               element={
-                user.email === "muhammedalibekir@gmail.com" ? (
+                isAdmin ? (
                   <Stats />
                 ) : (
                   <Navigate to="/" />


### PR DESCRIPTION
## Summary
- check logged-in user's role from Firestore
- restrict admin and stats routes to admins
- show Admin Panel link only for admins

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68794e5bf63083339e6c2e52657259a4