### PR TITLE
Show all users call logs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -511,14 +511,12 @@ export default function SiraTakip({ isAdmin }) {
               <h2 className="text-[clamp(1rem,1vw,1.5rem)] font-semibold mb-[0.8vh]">📋 Bugünkü Çağrı Kayıtları</h2>
               <div className="flex-1 min-h-0 overflow-y-auto">
                 <ul className="list-disc pl-[1vw] sm:pl-[1.5vw] text-[clamp(0.65rem,0.7vw,1rem)] space-y-[0.4vh]">
-                  {(logByDate[todayKey] || [])
-                    .filter((entry) => entry.person === userName)
-                    .map((entry, index) => (
-                      <li key={index}>
-                        {ensure24Hour(entry.time)} - {entry.person}{" "}
-                        {entry.action ? entry.action : "çağrıyı aldı"}
-                      </li>
-                    ))}
+                  {(logByDate[todayKey] || []).map((entry, index) => (
+                    <li key={index}>
+                      {ensure24Hour(entry.time)} - {entry.person}{" "}
+                      {entry.action ? entry.action : "çağrıyı aldı"}
+                    </li>
+                  ))}
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- show logs from all users in today's call records

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687a348c7bc48333953957374c102ef3