### PR TITLE
Add user permission management page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -297,12 +297,19 @@ export default function SiraTakip({ isAdmin }) {
               <p className="text-gray-800 truncate">
                 Hoş geldin, <span className="font-semibold text-blue-600">{userName || "Kullanıcı"}</span>
               </p>
-              {isAdmin && (
+              {isAdmin ? (
                 <a
                   href="/admin"
                   className="inline-block mt-[0.5vh] text-[clamp(0.7rem,0.5vw,1.2rem)] text-blue-500 hover:underline hover:text-blue-600 transition"
                 >
                   🔧 Admin Panel
+                </a>
+              ) : (
+                <a
+                  href="/permissions"
+                  className="inline-block mt-[0.5vh] text-[clamp(0.7rem,0.5vw,1.2rem)] text-blue-500 hover:underline hover:text-blue-600 transition"
+                >
+                  📝 İzin Paneli
                 </a>
               )}
             </div>

--- a/src/MainApp.js
+++ b/src/MainApp.js
@@ -8,6 +8,7 @@ import App from "./App";
 import Login from "./Login";
 import AdminPanel from "./AdminPanel";
 import Stats from "./Stats";
+import PermissionPage from "./PermissionPage";
 
 export default function MainApp() {
   const [user, setUser] = useState(null);
@@ -60,6 +61,16 @@ export default function MainApp() {
               element={
                 isAdmin ? (
                   <Stats />
+                ) : (
+                  <Navigate to="/" />
+                )
+              }
+            />
+            <Route
+              path="/permissions"
+              element={
+                !isAdmin ? (
+                  <PermissionPage />
                 ) : (
                   <Navigate to="/" />
                 )

--- a/src/PermissionPage.js
+++ b/src/PermissionPage.js
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { ref, get, set } from "firebase/database";
+import { auth, realtimeDB } from "./firebase";
+import { formatTime } from "./timeUtils";
+
+export default function PermissionPage() {
+  const [activeList, setActiveList] = useState([]);
+  const todayKey = new Date().toISOString().split("T")[0];
+
+  useEffect(() => {
+    const fetchList = async () => {
+      const snap = await get(ref(realtimeDB, "siraTakip/activeList"));
+      setActiveList(snap.val() || []);
+    };
+    fetchList();
+  }, []);
+
+  const toggleIzin = async (emp) => {
+    const activeRef = ref(realtimeDB, "siraTakip/activeList");
+    const snap = await get(activeRef);
+    const list = snap.val() || [];
+    const idx = list.findIndex((e) => e.uid === emp.uid);
+    if (idx === -1) return;
+    const newStatus = list[idx].status === "İzinli" ? "Müsait" : "İzinli";
+    list[idx].status = newStatus;
+    await set(activeRef, list);
+    setActiveList(list);
+
+    const changerUid = auth.currentUser?.uid;
+    const changerName =
+      list.find((e) => e.uid === changerUid)?.name ||
+      auth.currentUser?.displayName ||
+      "Kullanıcı";
+
+    const logRef = ref(realtimeDB, "siraTakip/logByDate");
+    const logSnap = await get(logRef);
+    const logData = logSnap.val() || {};
+    const entry = {
+      person: changerName,
+      time: formatTime(),
+      action:
+        newStatus === "İzinli"
+          ? `${emp.name} izinli yapıldı`
+          : `${emp.name} izinden çıkarıldı`,
+    };
+    const updatedForToday = [
+      entry,
+      ...(logData[todayKey] || []),
+    ].slice(0, 200);
+    const updatedLogs = { ...logData, [todayKey]: updatedForToday };
+    await set(logRef, updatedLogs);
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl mb-4">İzin Yönetimi</h1>
+      <table className="min-w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
+        <thead className="bg-gray-50 text-gray-700">
+          <tr>
+            <th className="px-3 py-2 text-left border-b">Ad</th>
+            <th className="px-3 py-2 text-center border-b">İzinli</th>
+            <th className="px-3 py-2 text-left border-b">İşlem</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200">
+          {activeList.map((emp) => (
+            <tr key={emp.uid} className="hover:bg-gray-50">
+              <td className="p-2 border">{emp.name}</td>
+              <td className="p-2 border text-center">
+                {emp.status === "İzinli" ? "✅" : "❌"}
+              </td>
+              <td className="p-2 border text-left">
+                <button
+                  onClick={() => toggleIzin(emp)}
+                  className="text-blue-600 hover:underline"
+                >
+                  {emp.status === "İzinli" ? "İzni Kaldır" : "İzin Ver"}
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add PermissionPage to allow users to toggle call tracking members' leave status and log who changed whom
- wire route `/permissions` for non-admin users
- link to permission page from main view for user role

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6895c83dc6d0833380664755f612b613