### PR TITLE
Add Firebase Storage photo upload feature

### DIFF
--- a/src/MainApp.js
+++ b/src/MainApp.js
@@ -9,6 +9,7 @@ import Login from "./Login";
 import AdminPanel from "./AdminPanel";
 import Stats from "./Stats";
 import PermissionPage from "./PermissionPage";
+import PhotoUpload from "./PhotoUpload";
 
 export default function MainApp() {
   const [user, setUser] = useState(null);
@@ -46,6 +47,7 @@ export default function MainApp() {
         ) : (
           <>
             <Route path="/" element={<App isAdmin={isAdmin} />} />
+            <Route path="/upload" element={<PhotoUpload />} />
             <Route
               path="/admin"
               element={

--- a/src/PhotoUpload.js
+++ b/src/PhotoUpload.js
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { storage } from "./firebase";
+import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
+
+export default function PhotoUpload() {
+  const [file, setFile] = useState(null);
+  const [url, setUrl] = useState("");
+
+  const handleChange = (e) => setFile(e.target.files[0]);
+
+  const handleUpload = async () => {
+    if (!file) return;
+    const storageRef = ref(storage, `photos/${file.name}`);
+    await uploadBytes(storageRef, file);
+    const downloadURL = await getDownloadURL(storageRef);
+    setUrl(downloadURL);
+  };
+
+  return (
+    <div className="p-4">
+      <input type="file" accept="image/*" onChange={handleChange} />
+      <button
+        onClick={handleUpload}
+        className="ml-2 px-2 py-1 bg-blue-500 text-white rounded"
+      >
+        Yükle
+      </button>
+      {url && (
+        <div className="mt-4">
+          <p>Resim URL'i:</p>
+          <a href={url} target="_blank" rel="noreferrer" className="text-blue-600 underline">
+            {url}
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -3,6 +3,7 @@ import { getDatabase } from "firebase/database";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { getFunctions } from "firebase/functions";
+import { getStorage } from "firebase/storage";
 
 const firebaseConfig = {
   apiKey: "AIzaSyB8JAzcgLPRP0MXYO3iC49vTpQFxSW-6K4",
@@ -19,4 +20,5 @@ export const auth = getAuth(app);
 export const realtimeDB = getDatabase(app);
 export const firestoreDB = getFirestore(app);
 export const functions = getFunctions(app, "europe-west1");
+export const storage = getStorage(app);
 


### PR DESCRIPTION
## Summary
- enable Firebase Storage in firebase setup
- add simple photo upload component and route

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ab078eea0c83339713a05bc8f64656